### PR TITLE
Add class to header text label for running timer

### DIFF
--- a/assets/javascripts/timer.js
+++ b/assets/javascripts/timer.js
@@ -245,7 +245,7 @@
 				{
 					var
 						tpl = $(
-							'<span style="margin-left:1em">' + lang._('title') + ': <a class="timerlog-timer-text"></a></span>'
+							'<span style="margin-left:1em;" class="timerlog-timer-label">' + lang._('title') + ': <a class="timerlog-timer-text"></a></span>'
 						),
 						a = tpl.find('a');
 


### PR DESCRIPTION
The "Timer" label for the running timer in the header area is white. With a theme that has a white header, it is invisible. This change simply adds a class to that span so it can be easily styled.
